### PR TITLE
Update bam_strings.xml

### DIFF
--- a/English (en_GB)/bam_strings.xml
+++ b/English (en_GB)/bam_strings.xml
@@ -332,4 +332,26 @@
     <string name="title_graphics">Graphics by Bliss91</string>
     <string name="title_plus_communtiy">Google+ community</string>
     <string name="title_git_translations">Translations</string>
+    
+    <!-- Missing code -->    
+    <string name="application_copyright">Copyright © 2014 CyanogenMod Projekt</string>
+    <string name="default_iconpack_title">Default icons</string>
+    <string name="filter_button_text">Filter</string>
+    <string name="icon_packs_title">Icon sets</string>
+    <string name="no_iconpacks_summary">Icon set is not installed</string>
+    <string name="preferences_application_title">App</string>
+    <string name="preferences_interface_dock_title">Dok panel</string>
+    <string name="preferences_interface_drawer_title">Apps menu</string>
+    <string name="preferences_interface_general_icons_category">Icon</string>
+    <string name="preferences_interface_general_icons_large_summary">Use large icons of the applications on the home screen and in the applications menu</string>
+    <string name="preferences_interface_general_icons_large_title">Large Icon</string>
+    <string name="preferences_interface_general_icons_text_style_summary">The choice of font style for signature badges</string>
+    <string name="preferences_interface_general_icons_text_style_title">Type font</string>
+    <string name="preferences_interface_general_title">General</string>
+    <string name="preferences_interface_homescreen_search_summary">Show search bar top of the screen</string>
+    <string name="preferences_interface_homescreen_title">Home screen</string>
+    <string name="preferences_title">Preferences</string>
+    <string name="transition_effect_button_text">Transition effect</string>
+    <string name="title_genius_hint">Look for something...</string>
+    <string name="title_genius_kill_all">Close all</string>
 </resources>


### PR DESCRIPTION
The main language file names should be all descriptions. Even if they do not exist in other languages​​, then they are taken from the main file in English - (res \ values ​​\ strings.xml). I added the code description that does not exist in the Basic English language file, but they are in other languages. It's not right and it should not be! Unfortunately, I was not able to break the codes into categories, but I think you do it yourself. Title I added my code named as "missing code"
